### PR TITLE
Fix weather market discovery: international cities, real Polymarket f…

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,13 +5,40 @@
 DATABASE_URL=sqlite:///./tradingbot.db
 # DATABASE_URL=postgresql://user:pass@localhost/tradingbot
 
-# Simulation settings
+# ── Trading mode ──────────────────────────────────────────
+# SIMULATION_MODE=true   → generate signals, record simulated trades (safe)
+# SIMULATION_MODE=false  → place REAL orders on Polymarket (requires credentials below)
 SIMULATION_MODE=true
 INITIAL_BANKROLL=10000
 KELLY_FRACTION=0.25
 MIN_EDGE_THRESHOLD=0.08
 
-# Kalshi API (RSA key auth for weather markets)
+# ── Polymarket CLOB live trading ───────────────────────────
+# Required to place real orders (SIMULATION_MODE=false, weather markets only)
+#
+# Step 1: Get your private key from MetaMask:
+#   MetaMask → Account Details → Export Private Key → paste here (no 0x prefix needed)
+#
+# Step 2: Your Polygon wallet address (checksummed):
+#   MetaMask → copy address from top of account view
+#
+# Step 3: USDC allowance — run once in browser before first trade:
+#   Go to https://polymarket.com → connect wallet → deposit USDC → approve contracts
+#
+# Step 4: API credentials — leave blank on first run, they will be auto-derived
+#   and printed to logs. Copy the output into these fields to skip re-derivation.
+#
+POLYMARKET_PRIVATE_KEY=
+POLYMARKET_FUNDER_ADDRESS=
+POLYMARKET_API_KEY=
+POLYMARKET_API_SECRET=
+POLYMARKET_API_PASSPHRASE=
+
+# ── Telegram notifications (optional) ─────────────────────
+TELEGRAM_BOT_TOKEN=
+TELEGRAM_CHAT_ID=
+
+# ── Kalshi API (RSA key auth for weather markets) ──────────
 KALSHI_API_KEY_ID=
 KALSHI_PRIVATE_KEY_PATH=
 KALSHI_ENABLED=true

--- a/backend/config.py
+++ b/backend/config.py
@@ -10,13 +10,24 @@ class Settings(BaseSettings):
     # Database (SQLite for Phase 1, PostgreSQL for production)
     DATABASE_URL: str = "sqlite:///./tradingbot.db"
 
-    # API Keys (optional)
+    # Polymarket CLOB trading (required for live orders)
+    # Get POLYMARKET_PRIVATE_KEY from MetaMask > Account Details > Export Private Key
+    # POLYMARKET_FUNDER_ADDRESS is your Polygon wallet address (checksummed)
+    # API credentials are auto-derived on first run and logged — copy them to .env
+    POLYMARKET_PRIVATE_KEY: Optional[str] = None
+    POLYMARKET_FUNDER_ADDRESS: Optional[str] = None
     POLYMARKET_API_KEY: Optional[str] = None
+    POLYMARKET_API_SECRET: Optional[str] = None
+    POLYMARKET_API_PASSPHRASE: Optional[str] = None
 
     # Kalshi API
     KALSHI_API_KEY_ID: Optional[str] = None
     KALSHI_PRIVATE_KEY_PATH: Optional[str] = None
     KALSHI_ENABLED: bool = True
+
+    # Telegram notifications (optional)
+    TELEGRAM_BOT_TOKEN: Optional[str] = None
+    TELEGRAM_CHAT_ID: Optional[str] = None
 
     # AI API Keys
     GROQ_API_KEY: Optional[str] = None
@@ -65,7 +76,7 @@ class Settings(BaseSettings):
     WEATHER_MIN_EDGE_THRESHOLD: float = 0.08  # 8% — weather has more signal than 5-min BTC
     WEATHER_MAX_ENTRY_PRICE: float = 0.70
     WEATHER_MAX_TRADE_SIZE: float = 100.0
-    WEATHER_CITIES: str = "nyc,chicago,miami,los_angeles,denver"
+    WEATHER_CITIES: str = "nyc,chicago,miami,los_angeles,denver,dallas,paris,london,tokyo,sao_paulo,singapore,wellington,buenos_aires,tel_aviv,sydney,toronto,berlin,dubai,amsterdam"
 
     class Config:
         env_file = ".env"

--- a/backend/core/scheduler.py
+++ b/backend/core/scheduler.py
@@ -10,6 +10,10 @@ import logging
 from backend.config import settings
 from backend.models.database import SessionLocal, Trade, BotState, Signal
 from backend.core.signals import scan_for_signals
+from backend.core.telegram import (
+    notify_startup, notify_order_placed, notify_trade_settled,
+    notify_signal_found, notify_error,
+)
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger("trading_bot")
@@ -183,6 +187,71 @@ async def scan_and_trade_job():
         logger.exception("Error in scan_and_trade_job")
 
 
+async def _place_polymarket_order(db, trade, signal, trade_size: float, entry_price: float):
+    """Place a real limit order on Polymarket CLOB and store the order ID."""
+    try:
+        from backend.data.polymarket_clob_client import (
+            polymarket_credentials_present,
+            place_limit_order,
+        )
+
+        if not polymarket_credentials_present():
+            log_event("warning", "Polymarket credentials not set — skipping live order")
+            return
+
+        # Choose YES or NO token based on signal direction
+        token_id = (
+            signal.market.yes_token_id
+            if signal.direction == "yes"
+            else signal.market.no_token_id
+        )
+        if not token_id:
+            log_event("warning",
+                f"No CLOB token ID for {signal.market.title} — skipping live order")
+            return
+
+        log_event("info",
+            f"Placing LIVE order: {signal.direction.upper()} "
+            f"${trade_size:.0f} @ {entry_price:.2f} | token {token_id[:12]}...")
+
+        response = await place_limit_order(
+            token_id=token_id,
+            price=entry_price,
+            size_usd=trade_size,
+            side="buy",
+        )
+
+        order_id = response.get("orderID") or response.get("id") or ""
+        order_status = response.get("status", "unknown")
+
+        if order_id:
+            trade.order_id = order_id
+            db.commit()
+            log_event("success",
+                f"LIVE ORDER submitted: {order_id[:16]}... status={order_status}",
+                {"order_id": order_id, "status": order_status, "response": response},
+            )
+            await notify_order_placed(
+                city=signal.market.city_name,
+                direction=signal.direction,
+                size_usd=trade_size,
+                price=entry_price,
+                edge=signal.edge,
+                order_id=order_id,
+                market_title=signal.market.title,
+            )
+        else:
+            log_event("warning",
+                f"Order submitted but no ID returned: {response}",
+                {"response": response},
+            )
+
+    except Exception as e:
+        log_event("error", f"Live order placement failed: {e}")
+        logger.exception("Error placing Polymarket live order")
+        await notify_error("Live order placement", str(e))
+
+
 async def weather_scan_and_trade_job():
     """
     Background job: Scan weather temperature markets, generate signals, execute trades.
@@ -296,6 +365,11 @@ async def weather_scan_and_trade_job():
                     }
                 )
 
+                # ── Live order placement ──────────────────────────────────
+                # When SIMULATION_MODE=False, send real orders to Polymarket
+                if not settings.SIMULATION_MODE and signal.market.platform == "polymarket":
+                    await _place_polymarket_order(db, trade, signal, trade_size, entry_price)
+
             state.last_run = datetime.utcnow()
             db.commit()
 
@@ -351,6 +425,15 @@ async def settlement_job():
                 for trade in settled:
                     result_prefix = "+" if trade.pnl and trade.pnl > 0 else ""
                     log_event("data", f"  {trade.event_slug}: {trade.result.upper()} {result_prefix}${trade.pnl:.2f}")
+                    if trade.market_type == "weather":
+                        await notify_trade_settled(
+                            city=trade.event_slug or "Unknown",
+                            direction=trade.direction,
+                            size_usd=trade.size,
+                            result=trade.result,
+                            pnl=trade.pnl or 0.0,
+                            market_title=trade.market_ticker or "",
+                        )
             else:
                 log_event("info", "No trades ready for settlement")
 
@@ -446,6 +529,14 @@ def start_scheduler():
         "min_edge": f"{settings.MIN_EDGE_THRESHOLD:.0%}",
         "weather_enabled": settings.WEATHER_ENABLED,
     })
+
+    db = SessionLocal()
+    try:
+        state = db.query(BotState).first()
+        bankroll = state.bankroll if state else settings.INITIAL_BANKROLL
+    finally:
+        db.close()
+    asyncio.create_task(notify_startup(settings.SIMULATION_MODE, bankroll))
 
     asyncio.create_task(scan_and_trade_job())
 

--- a/backend/core/telegram.py
+++ b/backend/core/telegram.py
@@ -1,0 +1,123 @@
+"""Telegram notifications for trade events.
+
+Setup:
+  1. Message @BotFather on Telegram → /newbot → copy the token
+  2. Start a chat with your new bot, then get your chat_id:
+       curl https://api.telegram.org/bot<TOKEN>/getUpdates
+     Look for "chat":{"id": <number>} in the response
+  3. Add to .env:
+       TELEGRAM_BOT_TOKEN=123456789:ABCdef...
+       TELEGRAM_CHAT_ID=987654321
+"""
+import logging
+import httpx
+from typing import Optional
+
+logger = logging.getLogger("trading_bot")
+
+_TELEGRAM_URL = "https://api.telegram.org/bot{token}/sendMessage"
+
+
+def _enabled() -> bool:
+    from backend.config import settings
+    return bool(settings.TELEGRAM_BOT_TOKEN and settings.TELEGRAM_CHAT_ID)
+
+
+async def send(message: str, parse_mode: str = "HTML") -> bool:
+    """Send a Telegram message. Returns True on success, False on failure."""
+    from backend.config import settings
+
+    if not _enabled():
+        return False
+
+    url = _TELEGRAM_URL.format(token=settings.TELEGRAM_BOT_TOKEN)
+    try:
+        async with httpx.AsyncClient(timeout=8.0) as client:
+            resp = await client.post(url, json={
+                "chat_id": settings.TELEGRAM_CHAT_ID,
+                "text": message,
+                "parse_mode": parse_mode,
+            })
+            resp.raise_for_status()
+            return True
+    except Exception as e:
+        logger.debug(f"Telegram send failed: {e}")
+        return False
+
+
+async def notify_order_placed(
+    city: str,
+    direction: str,
+    size_usd: float,
+    price: float,
+    edge: float,
+    order_id: str,
+    market_title: str,
+):
+    msg = (
+        f"🟢 <b>LIVE ORDER PLACED</b>\n"
+        f"📍 {city} — {market_title}\n"
+        f"↗ Direction: <b>{direction.upper()}</b>\n"
+        f"💵 Size: <b>${size_usd:.0f}</b> @ {price:.0%}\n"
+        f"📊 Edge: <b>{edge:+.1%}</b>\n"
+        f"🔑 Order: <code>{order_id[:20]}...</code>"
+    )
+    await send(msg)
+
+
+async def notify_trade_settled(
+    city: str,
+    direction: str,
+    size_usd: float,
+    result: str,
+    pnl: float,
+    market_title: str,
+):
+    icon = "✅" if result == "win" else "❌"
+    pnl_str = f"+${pnl:.2f}" if pnl >= 0 else f"-${abs(pnl):.2f}"
+    msg = (
+        f"{icon} <b>TRADE SETTLED — {result.upper()}</b>\n"
+        f"📍 {city} — {market_title}\n"
+        f"↗ Direction: {direction.upper()}\n"
+        f"💵 Size: ${size_usd:.0f}\n"
+        f"💰 P&L: <b>{pnl_str}</b>"
+    )
+    await send(msg)
+
+
+async def notify_signal_found(
+    city: str,
+    metric: str,
+    direction: str,
+    threshold_f: float,
+    edge: float,
+    model_prob: float,
+    market_prob: float,
+    platform: str,
+):
+    msg = (
+        f"🔍 <b>WEATHER SIGNAL</b> [{platform.upper()}]\n"
+        f"📍 {city}: {metric} <b>{direction}</b> {threshold_f:.0f}°F\n"
+        f"📊 Model: {model_prob:.0%} | Market: {market_prob:.0%} | Edge: <b>{edge:+.1%}</b>"
+    )
+    await send(msg)
+
+
+async def notify_error(context: str, error: str):
+    msg = (
+        f"⚠️ <b>BOT ERROR</b>\n"
+        f"Context: {context}\n"
+        f"Error: <code>{error[:200]}</code>"
+    )
+    await send(msg)
+
+
+async def notify_startup(simulation_mode: bool, bankroll: float):
+    mode = "SIMULATION" if simulation_mode else "🔴 LIVE TRADING"
+    msg = (
+        f"🤖 <b>Bot started — {mode}</b>\n"
+        f"💰 Bankroll: ${bankroll:,.0f}\n"
+        f"Weather scan: every 5 min\n"
+        f"Min edge: 8%"
+    )
+    await send(msg)

--- a/backend/core/weather_signals.py
+++ b/backend/core/weather_signals.py
@@ -60,12 +60,16 @@ async def generate_weather_signal(market: WeatherMarket) -> Optional[WeatherTrad
 
     # Calculate model probability based on market's question
     if market.metric == "high":
-        if market.direction == "above":
+        if market.direction == "range" and market.threshold_f_low is not None:
+            model_yes_prob = forecast.probability_high_in_range(market.threshold_f_low, market.threshold_f)
+        elif market.direction == "above":
             model_yes_prob = forecast.probability_high_above(market.threshold_f)
         else:
             model_yes_prob = forecast.probability_high_below(market.threshold_f)
     else:  # "low"
-        if market.direction == "above":
+        if market.direction == "range" and market.threshold_f_low is not None:
+            model_yes_prob = forecast.probability_low_in_range(market.threshold_f_low, market.threshold_f)
+        elif market.direction == "above":
             model_yes_prob = forecast.probability_low_above(market.threshold_f)
         else:
             model_yes_prob = forecast.probability_low_below(market.threshold_f)

--- a/backend/data/polymarket_clob_client.py
+++ b/backend/data/polymarket_clob_client.py
@@ -1,0 +1,188 @@
+"""Polymarket CLOB API client for real order placement.
+
+Authentication flow:
+  Level 1 (L1): private key + chain_id — used to sign orders and derive API keys
+  Level 2 (L2): L1 + API credentials (key/secret/passphrase) — used to POST orders
+
+Setup:
+  1. Set POLYMARKET_PRIVATE_KEY (hex, no 0x prefix needed) to your MetaMask private key
+  2. Set POLYMARKET_FUNDER_ADDRESS to your wallet's Polygon address
+  3. On first run, API credentials are derived automatically and logged — copy them to .env
+
+Required: pip install py-clob-client
+"""
+import asyncio
+import logging
+from typing import Optional
+
+logger = logging.getLogger("trading_bot")
+
+# Module-level singleton (initialized lazily)
+_clob_client = None
+
+
+def _init_clob_client():
+    """Initialize CLOB client synchronously (called once on first use)."""
+    global _clob_client
+    if _clob_client is not None:
+        return _clob_client
+
+    from backend.config import settings
+
+    if not settings.POLYMARKET_PRIVATE_KEY:
+        raise ValueError(
+            "POLYMARKET_PRIVATE_KEY not set. Add your MetaMask private key to .env"
+        )
+    if not settings.POLYMARKET_FUNDER_ADDRESS:
+        raise ValueError(
+            "POLYMARKET_FUNDER_ADDRESS not set. Add your Polygon wallet address to .env"
+        )
+
+    try:
+        from py_clob_client.client import ClobClient
+        from py_clob_client.clob_types import ApiCreds
+    except ImportError:
+        raise ImportError(
+            "py-clob-client not installed. Run: pip install py-clob-client"
+        )
+
+    client = ClobClient(
+        host="https://clob.polymarket.com",
+        key=settings.POLYMARKET_PRIVATE_KEY,
+        chain_id=137,  # Polygon mainnet
+        signature_type=0,  # Standard EOA — MetaMask / hardware wallet
+        funder=settings.POLYMARKET_FUNDER_ADDRESS,
+    )
+
+    # Use existing credentials if provided, otherwise derive from private key
+    if (
+        settings.POLYMARKET_API_KEY
+        and settings.POLYMARKET_API_SECRET
+        and settings.POLYMARKET_API_PASSPHRASE
+    ):
+        creds = ApiCreds(
+            api_key=settings.POLYMARKET_API_KEY,
+            api_secret=settings.POLYMARKET_API_SECRET,
+            api_passphrase=settings.POLYMARKET_API_PASSPHRASE,
+        )
+        client.set_api_creds(creds)
+        logger.info(
+            f"Polymarket CLOB: using stored API key {settings.POLYMARKET_API_KEY[:8]}..."
+        )
+    else:
+        logger.info("Polymarket CLOB: deriving API credentials from private key...")
+        creds = client.create_or_derive_api_creds()
+        client.set_api_creds(creds)
+        logger.info(
+            f"Polymarket CLOB: derived credentials. "
+            f"Add to .env to avoid re-derivation:\n"
+            f"  POLYMARKET_API_KEY={creds.api_key}\n"
+            f"  POLYMARKET_API_SECRET={creds.api_secret}\n"
+            f"  POLYMARKET_API_PASSPHRASE={creds.api_passphrase}"
+        )
+
+    _clob_client = client
+    return _clob_client
+
+
+def polymarket_credentials_present() -> bool:
+    """True if trading credentials are configured."""
+    from backend.config import settings
+    return bool(
+        settings.POLYMARKET_PRIVATE_KEY and settings.POLYMARKET_FUNDER_ADDRESS
+    )
+
+
+async def get_usdc_balance() -> float:
+    """Return current USDC balance available for trading on Polymarket."""
+    loop = asyncio.get_event_loop()
+    client = _init_clob_client()
+
+    def _fetch():
+        return float(client.get_balance())
+
+    return await loop.run_in_executor(None, _fetch)
+
+
+async def place_limit_order(
+    token_id: str,
+    price: float,
+    size_usd: float,
+    side: str = "buy",
+    neg_risk: bool = False,
+) -> dict:
+    """Place a GTC limit order on the Polymarket CLOB.
+
+    Args:
+        token_id: Outcome token ID (YES or NO token from clobTokenIds)
+        price:    Limit price in USDC, e.g. 0.62 for 62¢
+        size_usd: Dollar amount to spend (converted to shares internally)
+        side:     "buy" or "sell"
+        neg_risk: True for neg-risk multi-outcome markets (rare for weather)
+
+    Returns:
+        dict with "orderID", "status", "takingAmount", "makingAmount", etc.
+    """
+    try:
+        from py_clob_client.clob_types import OrderArgs, OrderType
+        from py_clob_client.order_builder.constants import BUY, SELL
+    except ImportError:
+        raise ImportError("py-clob-client not installed. Run: pip install py-clob-client")
+
+    # Clamp price to valid range and align to tick size (0.01)
+    price = round(max(0.01, min(0.99, price)), 2)
+
+    # Convert dollar amount to shares: spend $size_usd at $price/share
+    shares = round(size_usd / price, 2)
+    if shares < 1.0:
+        raise ValueError(
+            f"Order too small: ${size_usd:.2f} at {price:.2f} = {shares:.2f} shares (min 1)"
+        )
+
+    order_args = OrderArgs(
+        token_id=token_id,
+        price=price,
+        size=shares,
+        side=BUY if side == "buy" else SELL,
+    )
+
+    loop = asyncio.get_event_loop()
+    client = _init_clob_client()
+
+    def _create_and_post():
+        signed = client.create_order(
+            order_args,
+            options={"neg_risk": neg_risk},
+        )
+        return client.post_order(signed, OrderType.GTC)
+
+    response = await loop.run_in_executor(None, _create_and_post)
+    return response if isinstance(response, dict) else {}
+
+
+async def cancel_order(order_id: str) -> dict:
+    """Cancel an open order by its ID."""
+    loop = asyncio.get_event_loop()
+    client = _init_clob_client()
+
+    def _cancel():
+        return client.cancel(order_id)
+
+    return await loop.run_in_executor(None, _cancel)
+
+
+async def get_open_orders(market_id: Optional[str] = None) -> list:
+    """Return list of open orders, optionally filtered by market token_id."""
+    loop = asyncio.get_event_loop()
+    client = _init_clob_client()
+
+    def _fetch():
+        try:
+            from py_clob_client.clob_types import OpenOrderParams
+            params = OpenOrderParams(market=market_id) if market_id else OpenOrderParams()
+            return client.get_orders(params)
+        except Exception:
+            return client.get_orders()
+
+    result = await loop.run_in_executor(None, _fetch)
+    return result if isinstance(result, list) else []

--- a/backend/data/weather.py
+++ b/backend/data/weather.py
@@ -51,6 +51,76 @@ CITY_CONFIG: Dict[str, dict] = {
         "nws_office": "BOU",
         "nws_gridpoint": "BOU/62,60",
     },
+    "dallas": {
+        "name": "Dallas",
+        "lat": 32.7767,
+        "lon": -96.7970,
+    },
+    "paris": {
+        "name": "Paris",
+        "lat": 48.8566,
+        "lon": 2.3522,
+    },
+    "london": {
+        "name": "London",
+        "lat": 51.5074,
+        "lon": -0.1278,
+    },
+    "tokyo": {
+        "name": "Tokyo",
+        "lat": 35.6762,
+        "lon": 139.6503,
+    },
+    "sao_paulo": {
+        "name": "Sao Paulo",
+        "lat": -23.5505,
+        "lon": -46.6333,
+    },
+    "singapore": {
+        "name": "Singapore",
+        "lat": 1.3521,
+        "lon": 103.8198,
+    },
+    "wellington": {
+        "name": "Wellington",
+        "lat": -41.2865,
+        "lon": 174.7762,
+    },
+    "buenos_aires": {
+        "name": "Buenos Aires",
+        "lat": -34.6037,
+        "lon": -58.3816,
+    },
+    "tel_aviv": {
+        "name": "Tel Aviv",
+        "lat": 32.0853,
+        "lon": 34.7818,
+    },
+    "sydney": {
+        "name": "Sydney",
+        "lat": -33.8688,
+        "lon": 151.2093,
+    },
+    "toronto": {
+        "name": "Toronto",
+        "lat": 43.6532,
+        "lon": -79.3832,
+    },
+    "berlin": {
+        "name": "Berlin",
+        "lat": 52.5200,
+        "lon": 13.4050,
+    },
+    "dubai": {
+        "name": "Dubai",
+        "lat": 25.2048,
+        "lon": 55.2708,
+    },
+    "amsterdam": {
+        "name": "Amsterdam",
+        "lat": 52.3676,
+        "lon": 4.9041,
+    },
 }
 
 
@@ -99,6 +169,20 @@ class EnsembleForecast:
     def probability_low_below(self, threshold_f: float) -> float:
         """Fraction of ensemble members with daily low below threshold."""
         return 1.0 - self.probability_low_above(threshold_f)
+
+    def probability_high_in_range(self, low_f: float, high_f: float) -> float:
+        """Fraction of ensemble members with daily high between low_f and high_f (inclusive)."""
+        if not self.member_highs:
+            return 0.5
+        count = sum(1 for h in self.member_highs if low_f <= h <= high_f)
+        return count / len(self.member_highs)
+
+    def probability_low_in_range(self, low_f: float, high_f: float) -> float:
+        """Fraction of ensemble members with daily low between low_f and high_f (inclusive)."""
+        if not self.member_lows:
+            return 0.5
+        count = sum(1 for l in self.member_lows if low_f <= l <= high_f)
+        return count / len(self.member_lows)
 
     @property
     def ensemble_agreement(self) -> float:

--- a/backend/data/weather_markets.py
+++ b/backend/data/weather_markets.py
@@ -8,16 +8,28 @@ from typing import List, Optional
 
 logger = logging.getLogger("trading_bot")
 
-# Map city names/variants found in market titles to our city keys
+# Map city names found in market titles to our city keys
 CITY_ALIASES = {
+    "new york city": "nyc",
     "new york": "nyc",
     "nyc": "nyc",
-    "new york city": "nyc",
     "chicago": "chicago",
     "miami": "miami",
     "los angeles": "los_angeles",
-    "la": "los_angeles",
-    "denver": "denver",
+    "dallas": "dallas",
+    "paris": "paris",
+    "london": "london",
+    "tokyo": "tokyo",
+    "sao paulo": "sao_paulo",
+    "singapore": "singapore",
+    "wellington": "wellington",
+    "buenos aires": "buenos_aires",
+    "tel aviv": "tel_aviv",
+    "sydney": "sydney",
+    "toronto": "toronto",
+    "berlin": "berlin",
+    "dubai": "dubai",
+    "amsterdam": "amsterdam",
 }
 
 # Month name to number
@@ -42,81 +54,180 @@ class WeatherMarket:
     target_date: date
     threshold_f: float       # Temperature threshold in Fahrenheit
     metric: str              # "high" or "low"
-    direction: str           # "above" or "below"
+    direction: str           # "above", "below", or "range"
     yes_price: float         # Price of YES outcome (0-1)
     no_price: float          # Price of NO outcome (0-1)
     volume: float = 0.0
     closed: bool = False
+    # For range markets: low end of range (threshold_f is the high end)
+    threshold_f_low: Optional[float] = None
+    # CLOB token IDs for order placement (Polymarket only)
+    yes_token_id: Optional[str] = None
+    no_token_id: Optional[str] = None
+
+
+def _celsius_to_fahrenheit(c: float) -> float:
+    return c * 9.0 / 5.0 + 32.0
 
 
 def _parse_weather_market_title(title: str) -> Optional[dict]:
     """
-    Parse a weather market title to extract city, threshold, metric, date.
+    Parse a Polymarket weather market title.
 
-    Handles patterns like:
-    - "Will the high temperature in New York exceed 75°F on March 5?"
-    - "NYC high temperature above 80°F on March 10, 2026"
-    - "Chicago daily high over 60°F on March 3"
-    - "Will Miami's low be above 65°F on March 7?"
-    - "Temperature in Denver above 70°F on March 5, 2026"
+    Handles the actual Polymarket format:
+    - "Will the highest temperature in New York City be between 56-57°F on March 12?"
+    - "Will the highest temperature in Paris be 8°C on March 14?"
+    - "Will the highest temperature in Wellington be 10°C or below on March 14?"
+    - "Will the highest temperature in Dallas be 84°F or higher on March 13?"
     """
     title_lower = title.lower()
 
-    # Must be temperature-related
-    if not any(kw in title_lower for kw in ["temperature", "temp", "°f", "degrees", "high", "low"]):
+    # Must be a temperature market
+    if "temperature" not in title_lower:
         return None
 
-    # Extract city
+    # Extract city (try longest alias first to avoid partial matches)
     city_key = None
     city_name = None
-    for alias, key in sorted(CITY_ALIASES.items(), key=lambda x: -len(x[0])):
+    for alias in sorted(CITY_ALIASES.keys(), key=len, reverse=True):
         if alias in title_lower:
-            city_key = key
+            city_key = CITY_ALIASES[alias]
             from backend.data.weather import CITY_CONFIG
-            city_name = CITY_CONFIG[key]["name"]
+            city_name = CITY_CONFIG[city_key]["name"]
             break
 
     if not city_key:
         return None
 
-    # Extract threshold temperature
-    temp_match = re.search(r'(\d+)\s*°?\s*f', title_lower)
-    if not temp_match:
-        temp_match = re.search(r'(\d+)\s*degrees', title_lower)
-    if not temp_match:
-        return None
-    threshold_f = float(temp_match.group(1))
-
-    # Determine metric (high vs low)
-    metric = "high"  # default
-    if "low" in title_lower:
+    # Determine metric — "highest" or "lowest" temperature
+    metric = "high"
+    if "lowest" in title_lower or "minimum" in title_lower:
         metric = "low"
-
-    # Determine direction
-    direction = "above"  # default
-    if any(kw in title_lower for kw in ["below", "under", "less than", "drop below"]):
-        direction = "below"
 
     # Extract date
     target_date = _extract_date(title_lower)
     if not target_date:
         return None
 
-    return {
-        "city_key": city_key,
-        "city_name": city_name,
-        "threshold_f": threshold_f,
-        "metric": metric,
-        "direction": direction,
-        "target_date": target_date,
-    }
+    # ── Pattern 1: "between X-Y°F" ────────────────────────────────────────
+    range_f = re.search(r'between\s+(\d+(?:\.\d+)?)-(\d+(?:\.\d+)?)\s*°?\s*f', title_lower)
+    if range_f:
+        low_f = float(range_f.group(1))
+        high_f = float(range_f.group(2))
+        return {
+            "city_key": city_key,
+            "city_name": city_name,
+            "threshold_f": high_f,
+            "threshold_f_low": low_f,
+            "metric": metric,
+            "direction": "range",
+            "target_date": target_date,
+        }
+
+    # ── Pattern 2: "between X-Y°C" ────────────────────────────────────────
+    range_c = re.search(r'between\s+(\d+(?:\.\d+)?)-(\d+(?:\.\d+)?)\s*°?\s*c\b', title_lower)
+    if range_c:
+        low_f = _celsius_to_fahrenheit(float(range_c.group(1)))
+        high_f = _celsius_to_fahrenheit(float(range_c.group(2)))
+        return {
+            "city_key": city_key,
+            "city_name": city_name,
+            "threshold_f": high_f,
+            "threshold_f_low": low_f,
+            "metric": metric,
+            "direction": "range",
+            "target_date": target_date,
+        }
+
+    # Temperature number pattern — allows negative values
+    _NUM = r'-?\d+(?:\.\d+)?'
+
+    # ── Pattern 3: "X°F or higher" / "X°F or above" ───────────────────────
+    above_f = re.search(rf'({_NUM})\s*°?\s*f\s+or\s+(?:higher|above)', title_lower)
+    if above_f:
+        return {
+            "city_key": city_key,
+            "city_name": city_name,
+            "threshold_f": float(above_f.group(1)),
+            "threshold_f_low": None,
+            "metric": metric,
+            "direction": "above",
+            "target_date": target_date,
+        }
+
+    # ── Pattern 4: "X°C or higher" / "X°C or above" ───────────────────────
+    above_c = re.search(rf'({_NUM})\s*°?\s*c\b\s+or\s+(?:higher|above)', title_lower)
+    if above_c:
+        return {
+            "city_key": city_key,
+            "city_name": city_name,
+            "threshold_f": _celsius_to_fahrenheit(float(above_c.group(1))),
+            "threshold_f_low": None,
+            "metric": metric,
+            "direction": "above",
+            "target_date": target_date,
+        }
+
+    # ── Pattern 5: "X°F or below" / "X°F or under" ───────────────────────
+    below_f = re.search(rf'({_NUM})\s*°?\s*f\s+or\s+(?:below|under|less)', title_lower)
+    if below_f:
+        return {
+            "city_key": city_key,
+            "city_name": city_name,
+            "threshold_f": float(below_f.group(1)),
+            "threshold_f_low": None,
+            "metric": metric,
+            "direction": "below",
+            "target_date": target_date,
+        }
+
+    # ── Pattern 6: "X°C or below" / "X°C or under" ───────────────────────
+    below_c = re.search(rf'({_NUM})\s*°?\s*c\b\s+or\s+(?:below|under|less)', title_lower)
+    if below_c:
+        return {
+            "city_key": city_key,
+            "city_name": city_name,
+            "threshold_f": _celsius_to_fahrenheit(float(below_c.group(1))),
+            "threshold_f_low": None,
+            "metric": metric,
+            "direction": "below",
+            "target_date": target_date,
+        }
+
+    # ── Pattern 7: exact "X°C" (no qualifier = exact match market) ────────
+    exact_c = re.search(rf'be\s+({_NUM})\s*°?\s*c\b', title_lower)
+    if exact_c:
+        val_c = float(exact_c.group(1))
+        return {
+            "city_key": city_key,
+            "city_name": city_name,
+            "threshold_f": _celsius_to_fahrenheit(val_c + 0.5),
+            "threshold_f_low": _celsius_to_fahrenheit(val_c - 0.5),
+            "metric": metric,
+            "direction": "range",
+            "target_date": target_date,
+        }
+
+    # ── Pattern 8: exact "X°F" (no qualifier) ─────────────────────────────
+    exact_f = re.search(rf'be\s+({_NUM})\s*°?\s*f\b', title_lower)
+    if exact_f:
+        val = float(exact_f.group(1))
+        return {
+            "city_key": city_key,
+            "city_name": city_name,
+            "threshold_f": val + 0.5,
+            "threshold_f_low": val - 0.5,
+            "metric": metric,
+            "direction": "range",
+            "target_date": target_date,
+        }
+
+    return None
 
 
 def _extract_date(text: str) -> Optional[date]:
     """Extract a date from market title text."""
     today = date.today()
-
-    # Build month name pattern for precise matching
     month_names = "|".join(MONTH_MAP.keys())
 
     # Pattern: "March 5, 2026" or "March 5 2026" or "March 5"
@@ -148,71 +259,59 @@ def _extract_date(text: str) -> Optional[date]:
 
 async def fetch_polymarket_weather_markets(city_keys: Optional[List[str]] = None) -> List[WeatherMarket]:
     """
-    Search Polymarket for weather temperature markets.
-    Searches for temperature/weather events and parses their titles.
+    Fetch active weather temperature markets from Polymarket.
+
+    Polymarket temperature markets are standalone markets (no event grouping, no tags).
+    We page through /markets filtering by question content.
     """
     markets = []
+    seen_ids: set = set()
 
     try:
-        async with httpx.AsyncClient(timeout=15.0) as client:
-            # Search for weather/temperature events
-            for search_term in ["temperature", "weather high", "weather low"]:
+        async with httpx.AsyncClient(timeout=20.0) as client:
+            # Temperature markets have low 24h volume and appear at offset 1000-2000.
+            # Scan all pages up to 2500 entries.
+            for offset in range(0, 2500, 500):
                 try:
                     response = await client.get(
-                        "https://gamma-api.polymarket.com/events",
+                        "https://gamma-api.polymarket.com/markets",
                         params={
                             "closed": "false",
-                            "limit": 100,
-                            "tag": "Weather",
+                            "active": "true",
+                            "limit": 500,
+                            "offset": offset,
+                            "order": "volume24hr",
+                            "ascending": "false",
                         }
                     )
                     response.raise_for_status()
-                    events = response.json()
+                    batch = response.json()
+                    if not isinstance(batch, list) or not batch:
+                        break
 
-                    for event in events:
-                        event_slug = event.get("slug", "")
-                        for market_data in event.get("markets", []):
-                            market = _parse_polymarket_weather(market_data, event_slug, city_keys)
-                            if market:
-                                markets.append(market)
+                    for market_data in batch:
+                        question = market_data.get("question", "")
+                        if "temperature" not in question.lower():
+                            continue
 
-                except Exception as e:
-                    logger.debug(f"Weather market search for '{search_term}' failed: {e}")
-
-            # Also try slug-based search for known patterns
-            for slug_pattern in ["weather", "temperature", "temp-"]:
-                try:
-                    response = await client.get(
-                        "https://gamma-api.polymarket.com/events",
-                        params={
-                            "closed": "false",
-                            "limit": 100,
-                            "slug_contains": slug_pattern,
-                        }
-                    )
-                    response.raise_for_status()
-                    events = response.json()
-
-                    for event in events:
-                        event_slug = event.get("slug", "")
-                        for market_data in event.get("markets", []):
-                            market = _parse_polymarket_weather(market_data, event_slug, city_keys)
-                            if market and not any(m.market_id == market.market_id for m in markets):
-                                markets.append(market)
+                        market = _parse_polymarket_weather(market_data, city_keys)
+                        if market and market.market_id not in seen_ids:
+                            markets.append(market)
+                            seen_ids.add(market.market_id)
 
                 except Exception as e:
-                    logger.debug(f"Weather slug search for '{slug_pattern}' failed: {e}")
+                    logger.debug(f"Weather market fetch at offset {offset} failed: {e}")
+                    break
 
     except Exception as e:
         logger.warning(f"Failed to fetch weather markets: {e}")
 
-    logger.info(f"Found {len(markets)} weather temperature markets")
+    logger.info(f"Found {len(markets)} weather temperature markets on Polymarket")
     return markets
 
 
 def _parse_polymarket_weather(
     market_data: dict,
-    event_slug: str,
     city_keys: Optional[List[str]] = None,
 ) -> Optional[WeatherMarket]:
     """Parse a Polymarket market dict into a WeatherMarket if it's a temp market."""
@@ -250,16 +349,36 @@ def _parse_polymarket_weather(
     except (ValueError, IndexError):
         return None
 
-    # Skip resolved markets
+    # Skip resolved or near-resolved markets
     if market_data.get("closed", False):
         return None
-    if yes_price > 0.98 or yes_price < 0.02:
+    if yes_price > 0.97 or yes_price < 0.03:
+        return None
+
+    # Skip markets not accepting orders
+    if not market_data.get("acceptingOrders", True):
         return None
 
     volume = float(market_data.get("volume", 0) or 0)
 
+    # Extract CLOB token IDs for real order placement
+    clob_token_ids = market_data.get("clobTokenIds", [])
+    if isinstance(clob_token_ids, str):
+        import json as _json
+        try:
+            clob_token_ids = _json.loads(clob_token_ids)
+        except Exception:
+            clob_token_ids = []
+    yes_token_id = clob_token_ids[0] if len(clob_token_ids) > 0 else None
+    no_token_id = clob_token_ids[1] if len(clob_token_ids) > 1 else None
+
+    event_slug = ""
+    events = market_data.get("events", [])
+    if events and isinstance(events, list):
+        event_slug = events[0].get("slug", "") if events else ""
+
     return WeatherMarket(
-        slug=event_slug,
+        slug=event_slug or market_data.get("slug", ""),
         market_id=str(market_data.get("id", "")),
         platform="polymarket",
         title=question,
@@ -267,9 +386,12 @@ def _parse_polymarket_weather(
         city_name=parsed["city_name"],
         target_date=parsed["target_date"],
         threshold_f=parsed["threshold_f"],
+        threshold_f_low=parsed.get("threshold_f_low"),
         metric=parsed["metric"],
         direction=parsed["direction"],
         yes_price=yes_price,
         no_price=no_price,
         volume=volume,
+        yes_token_id=yes_token_id,
+        no_token_id=no_token_id,
     )

--- a/backend/models/database.py
+++ b/backend/models/database.py
@@ -41,6 +41,9 @@ class Trade(Base):
     result = Column(String, default="pending")  # pending, win, loss
     pnl = Column(Float, nullable=True)
 
+    # Real order tracking (populated when SIMULATION_MODE=False)
+    order_id = Column(String, nullable=True)   # Polymarket CLOB order ID
+
     # Model performance tracking
     model_probability = Column(Float)
     market_price_at_entry = Column(Float)
@@ -173,6 +176,11 @@ def ensure_schema():
         with engine.connect() as conn:
             with conn.begin():
                 conn.execute(text("ALTER TABLE trades ADD COLUMN market_type VARCHAR DEFAULT 'btc'"))
+
+    if "order_id" not in columns:
+        with engine.connect() as conn:
+            with conn.begin():
+                conn.execute(text("ALTER TABLE trades ADD COLUMN order_id VARCHAR"))
 
     # Add calibration columns to signals table
     try:

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,9 @@ pydantic-settings==2.1.0
 httpx==0.26.0
 aiohttp==3.9.1
 
+# Polymarket CLOB order execution (live trading)
+py-clob-client>=0.17.0
+
 # Kalshi API auth (RSA-PSS signatures)
 cryptography>=42.0.0
 


### PR DESCRIPTION
…ormat, CLOB trading

- Switch market fetch from /events?tag=Weather (broken) to /markets with offset pagination — temperature markets have no tags and appear at offset 1000+
- Rewrite title parser to handle actual Polymarket format: between X-Y°F, exact X°C, X°C or below, X°F or higher (including negative temps)
- Add Celsius-to-Fahrenheit conversion for international markets
- Add 14 international cities: Paris, London, Tokyo, Sao Paulo, Singapore, Wellington, Buenos Aires, Tel Aviv, Sydney, Toronto, Berlin, Dubai, Amsterdam, Dallas
- Add range probability methods to EnsembleForecast for range-direction markets
- Wire Polymarket CLOB client for real order placement on weather markets
- Add order_id column to Trade model with live migration
- Add Telegram notifications: startup, signal found, order placed, settled, errors