### PR TITLE
docs: add database configuration section

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,22 @@ pip install -r requirements.txt
 # Run the backend
 uvicorn backend.api.main:app --reload --port 8000
 ```
+### Database Configuration
+
+By default, the project uses SQLite and will automatically create a local database file:
+
+```env
+DATABASE_URL=sqlite:///./tradingbot.db
+```
+
+For PostgreSQL deployments, set a PostgreSQL database URL:
+
+```env
+DATABASE_URL=postgresql://user:password@host/database
+```
+
+Note: PostgreSQL deployments require PostgreSQL-compatible dependencies such as `psycopg2-binary`.
+
 
 Backend will be at: http://localhost:8000
 API docs at: http://localhost:8000/docs


### PR DESCRIPTION
## Summary

Adds a Database Configuration section to the README.

## Motivation

While investigating Issue #71, I found that:

* The default configuration uses SQLite.
* PostgreSQL is supported through the DATABASE_URL setting.
* The README did not explain the default database configuration or how to configure PostgreSQL.

This PR adds documentation for both SQLite and PostgreSQL database setups to make configuration clearer for new users.
